### PR TITLE
Fixed the "no results found" message bug

### DIFF
--- a/fraporu/ayvefya/reykunyu.js
+++ b/fraporu/ayvefya/reykunyu.js
@@ -1359,6 +1359,7 @@ function doSearchNavi() {
 						$("#sentence-bar .item").removeClass("active");
 						$item.addClass("active");
 						$fromNaviResult.find('.result').remove();
+						$fromNaviResult.find('.error').remove();
 						createResults(result, $fromNaviResult);
 					});
 				}


### PR DESCRIPTION
When you search for a word that does not exist there is an error message "No results found". If you then change tabs in the sentence bar, the error message remains displayed even if the word exists and there may also be several error messages. To fix this bug, I added a line that removes the old error message when changing tabs.