### PR TITLE
Fixed the affix tooltip bug

### DIFF
--- a/fraporu/tìlam/tìlam.css
+++ b/fraporu/tìlam/tìlam.css
@@ -337,6 +337,15 @@ h1::after {
 	overflow-x: auto;
 }
 
+.result .result-item.affixes .body {
+	overflow-x: visible;
+	padding-top: 8px;
+}
+
+.result .result-item.affixes table {
+	margin: 0;
+}
+
 .result .result-item.affixes table tr td:first-child {
 	font-weight: 700;
 }


### PR DESCRIPTION
When you search for a word composed of an affix like ngati, a message displays that -t is a suffix. If you hover over the suff label a tooltip appears but it is truncated and unreadable. I modified the css so that it displays correctly.